### PR TITLE
feat: ignore ErrorKind::BrokenPipe if using pager

### DIFF
--- a/crates/ruskel/src/main.rs
+++ b/crates/ruskel/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use libruskel::Ruskel;
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, ErrorKind, IsTerminal, Write};
 use std::process::{Command, Stdio};
 
 #[derive(Parser)]
@@ -81,7 +81,10 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     if io::stdout().is_terminal() && !cli.no_page {
-        page_output(&output)?;
+        match page_output(&output) {
+            Err(err) if err.kind() == ErrorKind::BrokenPipe => (),
+            r => r?,
+        };
     } else {
         println!("{}", output);
     }


### PR DESCRIPTION
Tool seems to throw a broken pipe error every time the pager goes away. Since you're spawning the pager yourself and you are already checking for a tty, maybe it's okay to ignore this error in that case?

Caveat: still relatively new to Rust, so feel free to correct unidiomatic code.

This was also just a quick patch to scratch my own itch, so if you think it would be better served deeper in the code, I can update the PR.